### PR TITLE
Add connect and disconnect commands

### DIFF
--- a/plugin/twitch-line-sign.vim
+++ b/plugin/twitch-line-sign.vim
@@ -79,18 +79,30 @@ function! s:Callback(channel, msg) abort
   call TwitchLineSignPlaceSign(a:msg.line, a:msg.nick, a:msg.suggestion)
 endfunction
 
-function! TwitchLineSignChatConnect() abort
-  let g:twitch_chat_connection = ch_open('localhost:6969', {
+function! TwitchLineSignChatConnect(...) abort
+  let host_port = a:0 ? a:1 : 'localhost:6969'
+  let ch = ch_open(host_port, {
         \ 'mode': 'json',
         \ 'callback': function('s:Callback'),
         \ })
+  if ch_status(ch) ==# 'open'
+    let g:twitch_chat_connection = ch
+    echo 'Connected'
+    return ''
+  else
+    return 'echoerr ' . string('Failed to connect')
+  endif
 endfunction
 
 function! TwitchLineSignChatDisconnect() abort
   if exists('g:twitch_chat_connection')
     call ch_close(g:twitch_chat_connection)
     unlet g:twitch_chat_connection
+    echo 'Disconnected'
+  else
+    echo 'No connection'
   endif
+  return ''
 endfunction
 
 augroup twitch
@@ -98,3 +110,5 @@ augroup twitch
   autocmd CursorMoved * call TwitchLineSignCheckLine() 
 augroup END
 
+command! -bar -nargs=? TwitchLineSignChatConnect    execute TwitchLineSignChatConnect(<f-args>)
+command! -bar          TwitchLineSignChatDisconnect execute TwitchLineSignChatDisconnect()

--- a/plugin/twitch-line-sign.vim
+++ b/plugin/twitch-line-sign.vim
@@ -50,29 +50,29 @@ function! TwitchLineSignCheckLine() abort
   echo echoString
 endfunction
 
-function! TwitchLineSignClearAllSigns() abort
-  for file in keys(s:currentSigns)
-    for line in keys(s:currentSigns[file])
-      for lineSign in s:currentSigns[file][line] 
-        exe "sign unplace " . lineSign.index
-      endfor
-    endfor
-  endfor
-  let s:currentSigns = {}
-endfunction
-
-function! TwitchLineSignClearSign() abort
+function! TwitchLineSignClear(line1, line2) abort
   let file = @%
   let line = line(".")
 
-  if has_key(s:currentSigns, file) && has_key(s:currentSigns[file], line)
-    let fileSigns = get(s:currentSigns, file)
-    let fileLineSigns = get(fileSigns, line)
-    for lineSign in fileLineSigns 
-      exe "sign unplace " . lineSign.index
-    endfor
-    let s:currentSigns[file][line] = []
-  endif
+  for line in range(a:line1, a:line2)
+    if has_key(s:currentSigns, file) && has_key(s:currentSigns[file], line)
+      let fileSigns = get(s:currentSigns, file)
+      let fileLineSigns = get(fileSigns, line)
+      for lineSign in fileLineSigns
+        exe "sign unplace " . lineSign.index
+      endfor
+      call remove(s:currentSigns[file], line)
+    endif
+  endfor
+  return ''
+endfunction
+
+function! TwitchLineSignClearAllSigns() abort
+  return TwitchLineSignClearSigns(1, line("$"))
+endfunction
+
+function! TwitchLineSignClearSign() abort
+  return TwitchLineSignClearSigns(line("."), line("."))
 endfunction
 
 function! s:Callback(channel, msg) abort
@@ -112,3 +112,4 @@ augroup END
 
 command! -bar -nargs=? TwitchLineSignChatConnect    execute TwitchLineSignChatConnect(<f-args>)
 command! -bar          TwitchLineSignChatDisconnect execute TwitchLineSignChatDisconnect()
+command! -bar -range   TwitchLineSignClear          execute TwitchLineSignClear(<line1>, <line2>)


### PR DESCRIPTION
Commands are generally a more comfortable user interface than having to
directly `:call` functions.  I've added two as an example, and leave the rest
as an exercise for the reader.

I'm using a pattern where the function returns a string to `:execute`.  This
is particularly useful for error handling, as it allows clean direct display
of an error message rather than including an ugly Vim stacktrace.  To that
end, I've added some rudimentary error handling as an example.  A caveat of
this approach is that if you forget to return a string, Vim will default to
returning `0`, which jumps to the top of the file.  So if that ever happens
for a command you're implementing, go back to the function and add a
`return ''`.